### PR TITLE
rub nose alert now appears in intervals of 100

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,8 @@ function rubit()
 	var timestamp = new Date().getTime();  
 	counter.src = "https://hitwebcounter.com/counter/counter.php?page=7290829&style=0008&nbdigits=5&type=page&initCount=0&t=" + timestamp
 	rubcount = rubcount + 1
-	if (rubcount > 100){
-		alert("Look dude you just rubbed Testudo's nose 100 times in a row. Are you okay?")
+	if (rubcount % 100 == 0){
+		alert(`Look dude you just rubbed Testudo's nose ${rubcount} times in a row. Are you okay?`)
 	}
 }
 


### PR DESCRIPTION
Hi there. I noticed the alert box for 100 rubs is persistent even after 100 rubs. This change shows the alert box in intervals of 100 rubs. The message is changed to show the rub count each interval. So the alert will appear at 100 rubs, but not at 101, then will appear again at 200 rubs, 300 rubs, etc. Here's the alert box at 200 rubs:
<img width="436" alt="Screen Shot 2020-05-22 at 11 43 46 AM" src="https://user-images.githubusercontent.com/25090614/82685987-1480df80-9c23-11ea-9d21-a3ce07546720.png">
